### PR TITLE
fix: send alias instead of name in request

### DIFF
--- a/app/controllers/api/v1/notify_controller.rb
+++ b/app/controllers/api/v1/notify_controller.rb
@@ -10,19 +10,23 @@ module Api
       def notify
         url = params[:URL_Tested]
         id_scan = params[:IdScann]
-        vulnerabilities = params[:Results]        
+        vulnerabilities = params[:Results]
         vulnerabilities.each do |vulnerability|
           vulnerability_name = vulnerability[:Vulnerability]
           vulnerability_status = vulnerability[:VulnerabilityStatus]
-          puts(vulnerability_status)
-          if vulnerability_status == "True"
+          if vulnerability_status
             create_security_flaw(url, find_vulnerability_id(vulnerability_name), id_scan)
           end
         end
         update_scan(id_scan)
-        logger.info(url)
         # Returning to python.
         render json: { 'message': "done" }
+      end
+
+      def print_debug(str, title = '')
+        puts "***************#{title}*****************"
+        puts "\t#{str}"
+        puts "***********END*#{title}*****************"
       end
 
       def update_scan(id_scan)
@@ -38,9 +42,8 @@ module Api
         logger.info('Created!')
       end
 
-      def find_vulnerability_id(vulnerability_name)
-        vulnerability = Vulnerability.where(['name like ?', "%#{vulnerability_name}%"]).first
-        vulnerability.id
+      def find_vulnerability_id(vulnerability_alias)
+        Vulnerability.where(['alias like ?', "%#{vulnerability_alias}%"]).first.id?
       end
     end
   end

--- a/app/controllers/scan_urls_controller.rb
+++ b/app/controllers/scan_urls_controller.rb
@@ -12,6 +12,7 @@ class ScanUrlsController < ApplicationController
     url = params[:url]
     analysis = Analysis.create(url: url,is_scan_completed: 0,analysis_date: DateTime.now, user_id: current_user.id)
     vulnerabilities = params[:vulnerabilities]
+
     result = HTTParty.post('http://127.0.0.1:5000/scanner/start'.to_str,
                            body: {
                             idScann: analysis.id,
@@ -19,8 +20,12 @@ class ScanUrlsController < ApplicationController
                             vulnerabilities: vulnerabilities
                            }.to_json,
                            headers: { 'Content-Type' => 'application/json' })
-    logger.info(result)
-    redirect_to 'http://127.0.0.1:3000/'
+    redirect_to 'http://localhost:3000/scan_urls'
   end
 
+  def print_debug(str, title = '')
+    puts "***************#{title}*****************"
+    puts "\t#{str}"
+    puts "***********END*#{title}*****************"
+  end
 end

--- a/app/views/scan_urls/_form_scanner.html.erb
+++ b/app/views/scan_urls/_form_scanner.html.erb
@@ -12,7 +12,7 @@
         <div class="col s6">
           <p>
             <label>
-              <%= check_box_tag "vulnerabilities[]", vulnerability %>
+              <%= check_box_tag "vulnerabilities[]", vulnerability.alias %>
               <span><%= vulnerability.name %></span>
             </label>
           </p>


### PR DESCRIPTION
Send vulnerability's alias in request to python instead of the name