### PR TITLE
hidden python backend endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,5 +20,4 @@ services:
     image: postgres:10.3-alpine
   python_server:
     image: python-scanner
-    ports:
-      - "5000:5000"
+  


### PR DESCRIPTION
with this modification, the python backend is only visible inside the docker container, no longer accessible by URL:5000. 